### PR TITLE
Reselect the last Visual area before builtin K.

### DIFF
--- a/autoload/ref.vim
+++ b/autoload/ref.vim
@@ -105,7 +105,11 @@ function! ref#K(mode)  " {{{2
   try
     call ref#jump(a:mode)
   catch /^ref:/
-    call feedkeys('K', 'n')
+    if a:mode ==# 'visual'
+      call feedkeys('gvK', 'n')
+    else
+      call feedkeys('K', 'n')
+    endif
   endtry
 endfunction
 


### PR DESCRIPTION
source が見つからず、通常の K へとフォールバックする状況で
ビジュアルモードから `<Plug>(ref-keyword)`  を実行した場合、キーワードがビジュアルモードによる選択範囲を反映せず cword になります。

ref#K() にて a:mode が 'visual' の場合は、K の前に gv することで対処してみました。
