### PR TITLE
Rのヘルプソース追加のお願い

### DIFF
--- a/autoload/ref/R.vim
+++ b/autoload/ref/R.vim
@@ -21,7 +21,7 @@ endfunction
 function! s:source.get_body(query)
   if a:query != ''
     let content = ref#system(ref#to_list(g:ref_R_cmd, a:query)).stdout
-    return substitute(content, '_', '', 'g')
+    return substitute(content, "_\<C-h>", '', 'g')
   endif
 endfunction
 
@@ -29,9 +29,7 @@ function! ref#R#define()
   return copy(s:source)
 endfunction
 
-if s:source.available()
-  call ref#register_detection('R', 'R')
-endif
+call ref#register_detection('rhelp', 'R')
 
 let &cpo = s:save_cpo
 unlet s:save_cpo


### PR DESCRIPTION
RのコマンドR -q -eの後にRのhelpを参照するコマンド(もしくは関数)で得られる出力をref.vimに流すだけしかまだ書けていないのですがpull requestを送らせて頂きます。

:Ref R ?cor
もしくは
:Ref R help(cor)

といったようにhelpを参照するコマンドもしくは関数を:Ref R の後に書くとRのhelpの出力結果をref.vimに流します。
出力の最初の1行目と末尾の数行に不要な出力が入る、syntax highlightが有効にできていない、キャッシュ機能を有効活用できていない等まだまだ至らないところだらけなのですが目を通して頂けると幸いです。
