### PR TITLE
Fix how to judge success/failure of "doc"(function-name search)

### DIFF
--- a/autoload/ref/clojure.vim
+++ b/autoload/ref/clojure.vim
@@ -38,8 +38,8 @@ function! s:source.get_body(query)
       let query = query[2 : -2]
     else
       let res = s:clj(printf('%s(doc %s)', pre, query))
-      let body = res.stdout
-      if body != ''
+      if res.stderr == '' && res.stdout != ''
+        let body = res.stdout
         let query = matchstr(body, '^-*\n\zs.\{-}\ze\n')
         return query != '' ? {'body': body, 'query': query} : body
       endif


### PR DESCRIPTION
## 問題

以下の条件を満たして `Clojure` ソースで関数名を検索すると、関数名が見つからない場合は `find-doc` による再検索が行なわれず `ref-viewer` にエラー(例外)メッセージが表示されます。

```
 * clojure-version < 1.3 Alpha 4
 * g:ref_use_vimproc == true
```
## 原因

1.3 Alpha 4 よりも前の `Clojure` では `doc` マクロの引数として、実行時のコンテキストに存在しない関数名を指定した場合、例外が発生します。(以降のバージョンは `find-doc` と同様に例外が発生しない)
`vimproc` を用いない場合は当該の例外メッセージが標準エラー出力にのみ格納されますが、`vimproc` を用いた場合は標準エラー出力(`stderr`)だけでなく、標準出力(`stdout`)にも例外メッセージが格納されています。
現在は標準出力に文字列が格納されているかで `doc` マクロの成否を判定しているため、結果として上記の問題が発生するようです。
## Vim その他環境

```
* OS:  Mac OS X Lion 10.7.3
* Vim: VIM - Vi IMproved 7.3 (2010 Aug 15, compiled Jan  5 2012 06:22:52)
       MacOS X (unix) 版
       適用済パッチ: 1-390
       Compiled by sakamoto@macbook.local
       Huge 版 with MacVim GUI.  機能の一覧 有効(+)/無効(-)
       +arabic +autocmd +balloon_eval +browse ++builtin_terms +byte_offset +cindent +clientserver +clipboard +cmdline_compl +cmdline_hist 
       +cmdline_info +comments +conceal +cryptv +cscope +cursorbind +cursorshape +dialog_con_gui +diff +digraphs +dnd -ebcdic +emacs_tags +eval 
       +ex_extra +extra_search +farsi +file_in_path +find_in_path +float +folding -footer +fork() +fullscreen +gettext +guess_encode -hangul_input 
       +iconv +insert_expand +jumplist +keymap +kaoriya +langmap +libcall +linebreak +lispindent +listcmds +localmap -lua +menu +migemo +mksession 
       +modify_fname +mouse +mouseshape +mouse_dec -mouse_gpm -mouse_jsbterm +mouse_netterm -mouse_sysmouse +mouse_xterm +mouse_urxvt +multi_byte 
       +multi_lang -mzscheme +netbeans_intg +odbeditor +path_extra +perl/dyn +persistent_undo +postscript +printer +profile +python/dyn +python3/dyn 
       +quickfix +reltime +rightleft +ruby/dyn +ruby19/dyn +scrollbind +signs +smartindent -sniff +startuptime +statusline -sun_workshop +syntax 
       +tag_binary +tag_old_static -tag_any_white -tcl +terminfo +termresponse +textobjects +title +toolbar +transparency +user_commands +vertsplit 
       +virtualedit +visual +visualextra +viminfo +vreplace +wildignore +wildmenu +windows +writebackup -X11 -xfontset +xim -xsmp -xterm_clipboard 
       -xterm_save 
             システム vimrc: "$VIM/vimrc"
               ユーザ vimrc: "$HOME/.vimrc"
                ユーザ exrc: "$HOME/.exrc"
            システム gvimrc: "$VIM/gvimrc"
              ユーザ gvimrc: "$HOME/.gvimrc"
           システムメニュー: "$VIMRUNTIME/menu.vim"
              省略時の $VIM: "/Applications/MacPorts/MacVim.app/Contents/Resources/vim"
       コンパイル: /usr/bin/gcc -c -I. -Iproto -DHAVE_CONFIG_H -DFEAT_GUI_MACVIM -Wall -Wno-unknown-pragmas -pipe  -I/opt/local/include  -DMACOS_X_UNIX -no-cpp-precomp  -pipe -O2  -arch x86_64 -arch i386 -arch x86_64 -arch i386 -D_FORTIFY_SOURCE=1      
       リンク: /usr/bin/gcc   -L. -L/opt/local/lib    -arch x86_64 -arch i386 -L/usr/local/lib -L. -L/opt/local/lib    -arch x86_64 -arch i386 -L/usr/local/lib -L.    -L.        -L/opt/local/lib -headerpad_max_install_names  -arch x86_64 -arch i386 -arch x86_64 -arch i386 -L/usr/local/lib -o Vim -framework Cocoa -framework Carbon      -lm  -lncurses -liconv -lintl -lmigemo -framework Cocoa            
```
