### PR TITLE
webdict ソースに start_linenumber オプションを追加してみました。

### DIFF
--- a/autoload/ref/webdict.vim
+++ b/autoload/ref/webdict.vim
@@ -7,6 +7,9 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 " options. {{{1
+if !exists('g:ref_source_webdict_start_linenumber')
+  let g:ref_source_webdict_start_linenumber = 0
+endif
 
 if !exists('g:ref_source_webdict_cmd')
   let g:ref_source_webdict_cmd =
@@ -90,6 +93,7 @@ function! s:source.get_body(query)
 endfunction
 
 function! s:source.opened(query)
+  execute "normal! ".g:ref_source_webdict_start_linenumber."z\<CR>"
   call s:syntax(matchstr(a:query, '^\s*\S*\s*\zs.*'))
   let b:ref_source_webdict_site = matchstr(a:query, '^\s*\zs\S*')
 endfunction


### PR DESCRIPTION
rfc ソースからの流用で、webdict ソースに start_linenumber オプションを追加してみました。

g:ref_source_webdict_start_linenumber が設定されていると、その行から結果を表示します。
デフォルトの値は0です。

(将来の拡張を考えるとwebdictのsitesごとに設定できた方が良いかもしれない感もありますが)
