### PR TITLE
Disabled folding because it is too heavy

### DIFF
--- a/autoload/ref/perldoc.vim
+++ b/autoload/ref/perldoc.vim
@@ -125,6 +125,8 @@ function! s:syntax(mode)
 
 
   syntax include @refPerldocPerl syntax/perl.vim
+  " if exists('perl_fold'), above set foldmethod=syntax and sometimes too slow. so disable it.
+  setlocal foldmethod=manual
 
   " Adjust the end of heredoc.
   syntax clear perlHereDoc


### PR DESCRIPTION
I'm using perl syntax with perl_fold = 1.
But this sometimes causes :Ref to freeze vim.
For workaround, set foldmethod=manual to enforce no folding.
