### PR TITLE
Fix refe parsing

### DIFF
--- a/autoload/ref/refe.vim
+++ b/autoload/ref/refe.vim
@@ -37,11 +37,16 @@ function! s:source.get_body(query)
   let content = res.stdout
   if s:refe_version() == 2
     " is class or module?
-    let class = matchstr(content, '^\v%(require\s+\S+\n\n)?%(class|module) \zs\S+')
+    let class = matchstr(content, '^\v%(require\s+\S+\n\n)?%(class|module) \zs%(\w|\:)+')
     if class != ''
       for [type, sep] in [['Singleton', '.'], ['Instance', '#']]
-        let members = s:refe(class . sep).stdout
-        let members = substitute(members, '\V' . class . sep, '', 'g')
+        let refe_result = s:refe(class . sep)
+        if refe_result.result != 0 " Members not found
+          let members = ''
+        else
+          let members = refe_result.stdout
+          let members = substitute(members, '\V' . class . sep, '', 'g')
+        endif
         let content .= "\n\n---- " . type . " methods ----\n" . members
       endfor
     endif


### PR DESCRIPTION
- Failing example: :Ref refe Enumerable

module Enumerable

繰り返しを行なうクラスのための Mix-in。このモジュールの
メソッドは全て each を用いて定義されているので、インクルード
するクラスには each が定義されていなければなりません。

---- Singleton methods ----
no such method: Enumerable.繰り返しを行なうクラスのための.

---- Instance methods ----
no such method: Enumerable.繰り返しを行なうクラスのための#
- Failing example: :Ref refe Object

class Object < BasicObject

include Kernel

全てのクラスのスーパークラス。
オブジェクトの一般的な振舞いを定義します。

このクラスのメソッドは上書きしたり未定義にしない限り、すべてのオブジェクトで使用することができます。

---- Singleton methods ----
/Users/t/local/refe/bitclust/lib/bitclust/completion.rb:474:in `entry':
undefined method`get_method' for #<spec new> (NoMethodError)
