### PR TITLE
Added normalizer for perldoc -f [built-in func]

### DIFF
--- a/autoload/ref/perldoc.vim
+++ b/autoload/ref/perldoc.vim
@@ -93,6 +93,15 @@ function! s:source.get_keyword()
   return kwd
 endfunction
 
+function! s:source.normalize(query)
+  let query = a:query
+  if query =~ '^[a-z]\+$'
+    " lower case, assume it to be built-in function
+    let query = '-f ' . query
+  endif
+  return query
+endfunction
+
 function! s:source.leave()
   unlet! b:ref_perldoc_mode b:ref_perldoc_word
   silent! nunmap <buffer> <Plug>(ref-source-perldoc-switch)


### PR DESCRIPTION
When a query only has lower-case characters,
append '-f' option to let perldoc search for built-in functions.
- pros: Jump to built-in functions are done by K key
  - symlink
  - eval
  - open
  - etc.
- cons: Jump to pragmas should use :Ref command
  - use strict
  - use warnings
  - use constant
  - etc.
