### PR TITLE
Check source.available before ref#register_detection

### DIFF
--- a/autoload/ref/clojure.vim
+++ b/autoload/ref/clojure.vim
@@ -120,7 +120,9 @@ function! ref#clojure#define()
   return copy(s:source)
 endfunction
 
-call ref#register_detection('clojure', 'clojure')
+if s:source.available()
+  call ref#register_detection('clojure', 'clojure')
+endif
 
 let &cpo = s:save_cpo
 unlet s:save_cpo

--- a/autoload/ref/refe.vim
+++ b/autoload/ref/refe.vim
@@ -329,7 +329,9 @@ function! ref#refe#define()
   return copy(s:source)
 endfunction
 
-call ref#register_detection('ruby', 'refe')
+if s:source.available()
+  call ref#register_detection('ruby', 'refe')
+endif
 
 let &cpo = s:save_cpo
 unlet s:save_cpo


### PR DESCRIPTION
one more thing in man.vim. Is it correct to associate c to manpage?

``` vim
if s:source.available()
  call ref#register_detection('c', 'man')
endif

```
