### PR TITLE
fix redis source

### DIFF
--- a/autoload/ref/redis.vim
+++ b/autoload/ref/redis.vim
@@ -138,7 +138,7 @@ function! s:list()
 endfunction
 
 function! s:head(list, query)
-  let pat = '^\V' . a:query . '\w\*\v(::)?\zs.*$'
+  let pat = '^\V' . a:query . '\S\*\v\zs.*$'
   return ref#uniq(map(filter(copy(a:list), 'v:val =~# pat'),
   \                   'substitute(v:val, pat, "", "")'))
 endfunction


### PR DESCRIPTION
```
  • ZREVRANGEBYSCORE key max min [WITHSCORES] [LIMIT offset count] Return a
    range of members in a sorted set, by score, with scores ordered from high
    to low
  • ZREVRANK key member Determine the index of a member in a sorted set, with
    scores ordered from high to low
  • ZSCORE key member Get the score associated with the given member in a
    sorted set
  • ZUNIONSTORE destination numkeys key [key ...] [WEIGHTS weight [weight ...]]
    [AGGREGATE SUM|MIN|MAX] Add multiple sorted sets and store the resulting
    sorted set in a new key
```

redis.io/commands から comamnd の一覧をこういうかたちで持ってきていて、それを `http:\/\/redis\.io\/commands\/\(.*\)` っていう正規表現でとろうとしていて、マッチ出来てなかったので大文字で続いてるそれっぽい単語を抽出するようにしたりしました。( 昔は http:// で書かれてたのかもしれません。)

`CONFIG SET` みたいなコマンドもあるので、これは `CONFIG-SET` にするようにしてあります。その影響で syntax の修正をしてます。

あと s:head が多分 perl から持ってきたままだったので合わせて修正しました。
