### PR TITLE
pydoc: extract/expand module path in python code

### DIFF
--- a/autoload/ref/pydoc.vim
+++ b/autoload/ref/pydoc.vim
@@ -130,7 +130,11 @@ function! s:source.get_keyword()
       endif
     endif
   else
-    " TODO: In a Python code.
+    " In Python code.
+    let module = s:ExpandModulePath()
+    if module != ''
+      return module
+    endif
   endif
 
   return ref#get_text_on_cursor('[[:alnum:].]\+')
@@ -198,6 +202,23 @@ function! s:head(list, query)
   let pat = '^\V' . a:query . '\v\w*(\.)?\zs.*$'
   return ref#uniq(map(filter(copy(a:list), 'v:val =~# pat'),
   \             'substitute(v:val, pat, "", "")'))
+endfunction
+
+function! s:ExpandModulePath()
+  " Extract the 'word' at the cursor, expanding leftwards across identifiers
+  " and the . operator, and rightwards across the identifier only.
+  "
+  " For example:
+  " import xml.dom.minidom
+  " ^ !
+  "
+  " With the cursor at ^ this returns 'xml'; at ! it returns 'xml.dom'.
+  "
+  " Source: https://github.com/fs111/pydoc.vim/blob/master/ftplugin/python_pydoc.vim
+  let l:line = getline(".")
+  let l:pre = l:line[:col(".") - 1]
+  let l:suf = l:line[col("."):]
+  return matchstr(pre, "[A-Za-z0-9_.]*$") . matchstr(suf, "^[A-Za-z0-9_]*")
 endfunction
 
 function! ref#pydoc#define()


### PR DESCRIPTION
s:ExpandModulePath is taken from @fs111's pydoc.vim:
https://github.com/fs111/pydoc.vim/blob/master/ftplugin/python_pydoc.vim
