### PR TITLE
clean code for man page option

### DIFF
--- a/autoload/ref.vim
+++ b/autoload/ref.vim
@@ -96,9 +96,9 @@ function! ref#complete(lead, cmd, pos)
   endtry
 endfunction
 
-function! ref#K(mode, count)
+function! ref#K(mode)
   try
-    call ref#jump(a:mode, {'page': v:count1})
+    call ref#jump(a:mode)
   catch /^ref:/
     if a:mode ==# 'visual'
       call feedkeys('gvK', 'n')
@@ -556,7 +556,7 @@ function! s:open(source, query, options)
 
   let query = source.normalize(a:query)
   try
-    let query = a:source=='man' && has_key(a:options, 'page') ? a:options.page . ' ' . query : query
+    let query = a:source=='man' ? v:count1 . ' ' . query : query
     let res = source.get_body(query)
     if type(res) == s:T.dictionary
       let dict = res

--- a/plugin/ref.vim
+++ b/plugin/ref.vim
@@ -15,8 +15,8 @@ set cpo&vim
 
 command! -nargs=+ -complete=customlist,ref#complete Ref call ref#ref(<q-args>)
 
-nnoremap <silent> <Plug>(ref-keyword) :<C-u>call ref#K('normal',v:count1)<CR>
-vnoremap <silent> <Plug>(ref-keyword) :<C-u>call ref#K('visual',v:count1)<CR>
+nnoremap <silent> <Plug>(ref-keyword) :<C-u>call ref#K('normal')<CR>
+vnoremap <silent> <Plug>(ref-keyword) :<C-u>call ref#K('visual')<CR>
 
 if !exists('g:ref_no_default_key_mappings') || !g:ref_no_default_key_mappings
   silent! nmap <silent> <unique> K <Plug>(ref-keyword)


### PR DESCRIPTION
before, i thought pass param like c, one function to one function.
but since v:count1 is always stored, so doesn't need pass it as
parameter.

still in ref.vim need a special judge for man, because in man.vim it
doesn't the query body from :Ref man keyword, or Shift+k with v:count1

i test at most case, so i think the code is stable.

Signed-off-by: xiehuc xiehuc@gmail.com
