### PR TITLE
ユーザーがg:ref_cache_dirを指定した場合expand()されない

### DIFF
--- a/autoload/ref.vim
+++ b/autoload/ref.vim
@@ -12,9 +12,7 @@ if !exists('g:ref_open')
   let g:ref_open = 'split'
 endif
 
-if !exists('g:ref_cache_dir')
-  let g:ref_cache_dir = expand('~/.vim_ref_cache')
-endif
+let g:ref_cache_dir = expand(get(g:, 'ref_cache_dir', '~/.vim_ref_cache'))
 
 if !exists('g:ref_use_vimproc')
   let g:ref_use_vimproc = globpath(&runtimepath, 'autoload/vimproc.vim') != ''


### PR DESCRIPTION
ユーザーが`g:ref_cache_dir`を指定した場合はexpand()されていません。

helpには

```
g:ref_cache_dir                                 g:ref_cache_dir
        キャッシュを保持しておくためのディレクトリです。ref#cache() はこの値
        を参照してキャッシュファイルを生成します。。デフォルト値は
        "~/.vim_ref_cache" です。~ はホームディレクトリを表します。
```

と記述があるため、ユーザーが値を指定した場合でも`~`がホームディレクトリに展開された方が自然であると思います。
