### PR TITLE
Use `python -m pydoc` as default for `g:ref_pydoc_cmd`

### DIFF
--- a/autoload/ref/pydoc.vim
+++ b/autoload/ref/pydoc.vim
@@ -9,7 +9,7 @@ set cpo&vim
 
 " options. {{{1
 if !exists('g:ref_pydoc_cmd')  " {{{2
-  let g:ref_pydoc_cmd = executable('pydoc') ? 'pydoc' : ''
+  let g:ref_pydoc_cmd = 'python -m pydoc'
 endif
 
 if !exists('g:ref_pydoc_complete_head')  " {{{2


### PR DESCRIPTION
`pydoc` is not being installed into a virtualenv
(see https://github.com/pypa/virtualenv/issues/149), but `python -m
pydoc` can work around this.
