### PR TITLE
[ref-perldoc] Support carton (aka Bundler for Perl).

### DIFF
--- a/doc/ref-perldoc.jax
+++ b/doc/ref-perldoc.jax
@@ -1,6 +1,6 @@
 *ref-perldoc.txt*	perldoc 用の ref ソース。
 
-Version: 0.3.4
+Version: 0.3.5
 Author : thinca <thinca+vim@gmail.com>
 License: クリエイティブ・コモンズの表示 2.1 日本ライセンス
          <http://creativecommons.org/licenses/by/2.1/jp/>
@@ -110,6 +110,9 @@ b:ref_perldoc_word				*b:ref_perldoc_word*
 
 ==============================================================================
 更新履歴					*ref-perldoc-changelog*
+
+0.3.5	2015-05-17
+	- cartonに対応
 
 0.3.4	2011-02-10
 	- 補完候補に対して |ref#uniq()| を呼ぶようにした。

--- a/doc/ref-perldoc.jax
+++ b/doc/ref-perldoc.jax
@@ -112,7 +112,7 @@ b:ref_perldoc_word				*b:ref_perldoc_word*
 更新履歴					*ref-perldoc-changelog*
 
 0.3.5	2015-05-17
-	- cartonに対応
+	- carton に対応した。
 
 0.3.4	2011-02-10
 	- 補完候補に対して |ref#uniq()| を呼ぶようにした。

--- a/doc/ref-perldoc.txt
+++ b/doc/ref-perldoc.txt
@@ -1,6 +1,6 @@
 *ref-perldoc.txt*	A ref source for perldoc.
 
-Version: 0.3.4
+Version: 0.3.5
 Author : thinca <thinca+vim@gmail.com>
 License: Creative Commons Attribution 2.1 Japan License
          <http://creativecommons.org/licenses/by/2.1/jp/deed.en>
@@ -114,6 +114,9 @@ BUGS						*ref-perldoc-bugs*
 
 ==============================================================================
 CHANGELOG					*ref-perldoc-changelog*
+
+0.3.5	2015-05-17
+	- Support carton.
 
 0.3.4	2011-02-10
 	- Use |ref#uniq()| for the completion candidates.


### PR DESCRIPTION
Cartonを使うと、カレントのlocalディレクトリに依存モジュールをローカルインストールすることができます。
が、ref-perldocではローカルインストールしたモジュールのPODを引けなかったため、引けるようにしました。

キャッシュを持ち越すと微妙な挙動をしますが、それはちょっとどうしようもないかなーと思ってます。