### PR TITLE
Add g:ref_man_manpath option for man

### DIFF
--- a/autoload/ref/man.vim
+++ b/autoload/ref/man.vim
@@ -117,7 +117,9 @@ endfunction
 
 function! s:source.option(opt)
   if a:opt ==# 'manpath'
-    return ref#system('manpath').stdout
+    return exists('g:ref_man_manpath') ? g:ref_man_manpath :
+    \	            $MANPATH !=# '' ? $MANPATH :
+    \	            ref#system('manpath').stdout
   endif
   return g:ref_man_{a:opt}
 endfunction

--- a/doc/ref-man.txt
+++ b/doc/ref-man.txt
@@ -48,6 +48,10 @@ g:ref_man_lang					*g:ref_man_lang*
 			It is used for the value of $LANG when it is not empty
 			string.
 
+g:ref_man_manpath				*g:ref_man_manpath*
+			Specifies the list of directories to search for man
+			pages.  Separate directories with colons.
+
 
 
 ==============================================================================


### PR DESCRIPTION
Not all systems have an executable named `manpath`.  As a result, caching of man directories doesn't work on those systems.

The patch below adds a new option `g:ref_man_manpath` for the `man` source.  If this option is unset, the environment variable `MANPATH` is used.  If the environment variable `MANPATH` is also unset, `manpath` is run, and the result is used as a list of directories to search for man pages.