### PR TITLE
Fix URL for downloading the PHP manual

### DIFF
--- a/doc/ref-phpmanual.jax
+++ b/doc/ref-phpmanual.jax
@@ -21,7 +21,7 @@ License: クリエイティブ・コモンズの表示 2.1 日本ライセンス
 
 要件:
 - |ref.vim| 0.3.2 以降
-- PHP Manual (Many HTML files) (http://php.benscom.com/download-docs.php)
+- PHP Manual (Many HTML files) (http://www.php.net/download-docs.php)
 
 
 

--- a/doc/ref-phpmanual.txt
+++ b/doc/ref-phpmanual.txt
@@ -21,7 +21,7 @@ INTRODUCTION					*ref-phpmanual-introduction*
 
 Requirements:
 - |ref.vim| 0.3.2 or later
-- PHP Manual (Many HTML files) (http://php.benscom.com/download-docs.php)
+- PHP Manual (Many HTML files) (http://www.php.net/download-docs.php)
 
 
 


### PR DESCRIPTION
The URL for downloading the PHP manual should be the [official page][phpman].

[phpman]: http://www.php.net/download-docs.php