### PR TITLE
Fix ref#system for Windows

### DIFF
--- a/autoload/ref.vim
+++ b/autoload/ref.vim
@@ -372,9 +372,13 @@ function! ref#system(args, ...)
     " By occasion of above, the command should be converted to fullpath.
     let args[0] = s:cmdpath(args[0])
     let q = '"'
-    let cmd = q . join(map(args,
-    \   'q . substitute(escape(v:val, q), "[<>^|&]", "^\\0", "g") . q'),
-    \   ' ') . q
+    let cmd = join(map(args, 'q .' .
+    \   ((exists('&sxe') && &sxe != '') || has('nvim') ? ' v:val ' :
+    \   ' substitute(escape(v:val, q), "[<>^|&]", "^\\0", "g") ') .
+    \   '. q'))
+    if !exists('&sxq') || &sxq == '' || has('nvim')
+      let cmd = q . cmd . q
+    endif
   else
     let cmd = join(map(args, 'shellescape(v:val)'))
   endif


### PR DESCRIPTION
Windows で sxq, sxe が設定されている場合、call_shell の処理でコマンドが二重にクォート・エスケープされてしまい　ref#system が正常に動作しないようだったので修正しました。
nvim については libuv_process_spawn で UV_PROCESS_WINDOWS_VERBATIM_ARGUMENT が指定されているため外側の " は必要なようです。処理を追いきれなかったのでよくわからないのですが、`C:\^a b` というディレクトリを作成したうえで中に test.txt を作成し、

```vim
sysmtem('""ls" "C:\^a b""')
```
してみたところ、test.txt が表示されましたので &<>()@^| の ^ でのエスケープ処理はされているようです。

よろしければ取り込んで頂けますか。
