### PR TITLE
Improve <Plug>(ref-keyword)

### DIFF
--- a/autoload/ref.vim
+++ b/autoload/ref.vim
@@ -99,12 +99,14 @@ endfunction
 function! ref#K(mode)
   try
     call ref#jump(a:mode)
-  catch /^ref:/
+  catch /^ref: The source is not registered:/
     if a:mode ==# 'visual'
       call feedkeys('gvK', 'n')
     else
       call feedkeys('K', 'n')
     endif
+  catch /^ref:/
+    call s:echoerr(v:exception)
   endtry
 endfunction
 

--- a/autoload/ref.vim
+++ b/autoload/ref.vim
@@ -526,9 +526,18 @@ endfunction
 function! s:get_query(mode, source)
   let [source, query] = [a:source, '']
   if a:mode ==# 'normal'
-    let pos = getpos('.')
-    let res = s:sources[source].get_keyword()
-    call setpos('.', pos)
+    try
+      let pos = getpos('.')
+      let res = s:sources[source].get_keyword()
+    catch
+      let mes = v:exception
+      if mes =~# '^Vim'
+        let mes .= "\n" . v:throwpoint
+      endif
+      throw printf('ref: %s: %s', source, mes)
+    finally
+      call setpos('.', pos)
+    endtry
     if type(res) == s:T.list && len(res) == 2
       let [source, query] = res
     else

--- a/doc/ref.jax
+++ b/doc/ref.jax
@@ -337,6 +337,8 @@ get_keyword()				*ref-source-attr-get_keyword()*
 			[{source-name}, {keyword}] の形式のリストを返すことも
 			できます。この場合指定されたソースでキーワードが開かれ
 			ます。
+			キーワードが見つからない場合はエラーメッセージと共に例
+			外を投げます。
 
 complete({query})			*ref-source-attr-complete()*
 			任意。コマンドラインの補完リストを返します。

--- a/doc/ref.txt
+++ b/doc/ref.txt
@@ -342,6 +342,8 @@ get_keyword()				*ref-source-attr-get_keyword()*
 			The list of the form of [{source-name}, {keyword}] can
 			be returned.  In this case, the keyword is opened by
 			the specified source.
+			Throws an exception with an error message if keyword
+			is not found.
 
 complete({query})			*ref-source-attr-complete()*
 			Optional.  Return the completion list for command-line.


### PR DESCRIPTION
I changed the behavior of `<Plug>(ref-keyword)` a little. This patch consists of two commits. The details are as follows.

## 1. https://github.com/thinca/vim-ref/commit/8c282e3c172debe24060808d1ebc68ef99288729

### Problem
When `get_body()` (`ref-source-attr-get_body()`) is called from `<Plug>(ref-keyword)` (`ref#K`) and throws an exception with an error message, the error message is not displayed. Instead, `keywordprg` is called. This is because we always fall back to `K` when any exception is caught.

### Solution
Fall back to `K` ONLY when source is not found, and display any other exception as an error message. This way, exception thrown by `get_body()` will always be displayed.

## 2. https://github.com/thinca/vim-ref/pull/65/commits/1777190eff396b9e38d26d3bffecf49c07132009

### Problem
Cannot display error message such as `E349: No identifier under cursor`.

### Solution
Catch an exception thrown by `get_keyword()` (`ref-source-attr-get_keyword()`) and display it as an error message. This will work in combination with the previous commit (https://github.com/thinca/vim-ref/commit/8c282e3c172debe24060808d1ebc68ef99288729).